### PR TITLE
Soporte para Kubernetes en la CLI y ejecución de comandos en Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,24 @@
 Agrega manifiesto para despliegue enb Kubernetes
 Se modifca el archivo Dockerfile para poder hacer
 el despliegue. Commit: `e38eddb`
+
+## Dia 4
+- **YoelMantari**: listar pods de kubernetes desde la cli
+
+se añade la funcion listar_pods(), que imprime en forma enumerada los pods. Commit: `2fd72dd`
+
+- **YoelMantari**: mejorar seleccion de contenedor por id o nombre
+
+se actualiza la funcion seleccionar_contenedor() para que se ingresar el id o nombre del contenedor en lugar de indice. Commit: `c27325a`
+
+- **YoelMantari**: permitir seleccion de pod por numero desde la cli
+
+se añade la funcion seleccionar_pod() que solicita al usuario ingresar un numero que esta listado por indice. Commit: `ab05660`
+
+- **YoelMantari**: ejecutar comandos dentro de pods Kubernetes
+
+se implementa la funcion ejecutar_comando_k8s() que ejecuta un comando, detecta si es bash y permite interacion directa con pods desde la cli. Commit: `1c5ac21`
+
+- **YoelMantari**: adaptar main para soporte de docker y kubernetes
+
+se actualiza la el main para seleccionar tanto contenedores docker como en pods de kubernetes. Commit: `583c94e`

--- a/README.md
+++ b/README.md
@@ -110,8 +110,15 @@ Probar un comando dentro del Pod
 ```sh
 kubectl exec -it simple-app-deployment-<identificador> -- ping -c 4 google.com
 ```
-
-
+### Paso 6
+Ejecutar en un pode de kubernetes en modo k8s
+```sh
+python3 cli/container_exec.py --platform k8s
+```
+Ejecutar en un contenedor Docker en modo docker
+```sh
+python3 cli/container_exec.py --platform docker
+```
 
 ## Sprint 1
 
@@ -158,7 +165,7 @@ Ejecutar ping (como ejemplo)
 ### Paso 2
 Ejecutar el script:
 ```sh
-python3 container_exec.py
+python3 cli/container_exec.py
 ```
 Se mostrara un listado numerado de contenedores activos.
 Por ejemplo (ps, ps aux, ping, ls, ... etc)

--- a/cli/container_exec.py
+++ b/cli/container_exec.py
@@ -25,6 +25,24 @@ def listar_contenedores() -> list[str]:
     return contenedores
 
 
+def listar_pods() -> list[str]:
+    """
+    Lista pods en Kubernetes
+    """
+    resultado = subprocess.run(
+        ["kubectl", "get", "pods", "-o", "custom-columns=NAME:.metadata.name"],
+        stdout=subprocess.PIPE, text=True, check=True
+    )
+    pods = resultado.stdout.strip().splitlines()[1:]  
+    if not pods:
+        print("No hay pods en el namespace actual.")
+        sys.exit(0)
+    print("\nPods Kubernetes activos:")
+    for i, pod in enumerate(pods, 1):
+        print(f"{i}. {pod}")
+    return pods
+
+
 def seleccionar_contenedor(contenedores: list[str]) -> str:
     """
     Permite al usuario selecciona un contenedor por indice,

--- a/cli/container_exec.py
+++ b/cli/container_exec.py
@@ -80,6 +80,20 @@ def ejecutar_comando(contenedor_id: str, comando: list[str]) -> None:
     print(resultado.stderr)
 
 
+def seleccionar_pod(pods: list[str]) -> str:
+    """
+    Solicita al usuario que seleccione un pod por número.
+    Devuelve el nombre del pod.
+    """
+    while True:
+        entrada = input("\nSelecciona un pod (numero): ").strip()
+        if entrada.isdigit():
+            idx = int(entrada) - 1
+            if 0 <= idx < len(pods):
+                return pods[idx]
+        print(f"'{entrada}' no es un número valido. Intenta nuevamente.")
+
+
 def main():
     contenedores = listar_contenedores()
     contenedor_id = seleccionar_contenedor(contenedores)

--- a/cli/container_exec.py
+++ b/cli/container_exec.py
@@ -91,7 +91,17 @@ def seleccionar_pod(pods: list[str]) -> str:
             idx = int(entrada) - 1
             if 0 <= idx < len(pods):
                 return pods[idx]
-        print(f"'{entrada}' no es un número valido. Intenta nuevamente.")
+        print(f"'{entrada}' no es un numero valido, intentarlo de nuevo")
+
+
+def ejecutar_comando_k8s(pod: str, comando: list[str]) -> None:
+    """
+    Ejecuta comando arbitrario dentro de un pod de Kubernetes.
+    usando flags para interactuar en bash
+    """
+    flags = ["-i", "-t"] if comando and comando[0] in ("bash", "sh") else []
+    cmd = ["kubectl", "exec"] + flags + [pod, "--"] + comando
+    subprocess.run(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
 
 
 def main():

--- a/cli/container_exec.py
+++ b/cli/container_exec.py
@@ -45,21 +45,21 @@ def listar_pods() -> list[str]:
 
 def seleccionar_contenedor(contenedores: list[str]) -> str:
     """
-    Permite al usuario selecciona un contenedor por indice,
-    se lista los contenedores disponibles
-    retorna el id del contenedor seleccionado
+    Solicita al usuario que ingrese un ID o nombre 
+    valido hasta que lo haga correctamente.
+    Devuelve el ID del contenedor correspondiente.
     """
-    try:
-        indice = int(input("\nSelecciona un contenedor (numero): ")) - 1
-    except ValueError:
-        print("Entrada invalida, debe ser un numero entero")
-        sys.exit(1)
-
-    if 0 <= indice < len(contenedores):
-        return contenedores[indice].split(":")[0]
-    else:
-        print("Índice inválido.")
-        sys.exit(1)
+    while True:
+        entrada = input("\nSelecciona un contenedor (ID o nombre): ").strip()
+        for cont in contenedores:
+            try:
+                cid, resto = cont.split(":", 1)
+                nombre = resto.split(" - ")[1].strip()
+                if entrada == cid or entrada == nombre:
+                    return cid
+            except (IndexError, ValueError):
+                continue  # ignorar formatos inesperados
+        print(f"'{entrada}' no coincide con ningun ID o nombre listado, intentarlo de nuevo")
 
 
 def ejecutar_comando(contenedor_id: str, comando: list[str]) -> None:


### PR DESCRIPTION
Se agrega soporte para Kubernetes en la cli  `container_exec.py`. 

- Listar Pods activos.
- Seleccionar un Pod por número.
- Ejecutar comandos en Pods con `kubectl exec`.
- Ejecutar comandos interactivos como `bash`.

Ademas se actualiza el `README.md` con instrucciones de uso y el `CHANGELOG.md` con los cambios del Sprint 2.

Closes #13 