### PR TITLE
ci(workflow): agregar escaneo anti-plagio al pipeline CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,6 +18,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # escaneo para uso de anti plageo
+      - name: Escaneo anti-plagio
+        run: |
+          grep -RIE \
+            --exclude-dir=.git \
+            --exclude-dir=.github \
+            --exclude='CI.yaml' \
+            -e "chatgpt" \
+            -e "bard" \
+            -e "llama" \
+            -e "as an ai" \
+            -e "🧩" \
+            -e "🧠" \
+            -e "✅" \
+            -e "🧪" \
+            . && exit 1 || exit 0
+
       # detectar duplicación con jscpd
       - name: Instalar Node.js y jscpd
         uses: actions/setup-node@v3


### PR DESCRIPTION
- Se agrego un paso de escaneo anti-plagio en el workflow de CI para detectar terminos relacionados con IA.
-Se excluyen archivos internos del pipeline para evitar falsos positivos.
